### PR TITLE
Added --no-quit flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN apk add --update ruby ruby-dev ruby-etc ruby-bigdecimal sqlite sqlite-dev bu
 EXPOSE 1025 1080
 
 ENTRYPOINT ["mailcatcher", "--foreground"]
-CMD ["--ip", "0.0.0.0"]
+CMD ["--ip", "0.0.0.0", "--no-quit"]


### PR DESCRIPTION
Consider adding `--no-quit` because the application lifecycle should be managed by Docker rather than from the web UI. Note that the [most popular MailCatcher image](https://hub.docker.com/r/schickling/mailcatcher) with over 10 million pulls [also does this](https://github.com/schickling/dockerfiles/blob/master/mailcatcher/Dockerfile).