### PR TITLE
fix: lock alpine to 3.18 to avoid "symbol not found"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.18
 
 ARG VERSION=0.9.0
 


### PR DESCRIPTION
fix #11 